### PR TITLE
Fixed undefined method bug

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,10 +1,10 @@
 class ArticlesController < ApplicationController
-  
-  http_basic_authenticate_with name: "dhh", password: "secret", except: [:index, :show]
-  
+
+  http_basic_authenticate_with name: "dhh", password: "secret", except: [:index, :show]
+
 
   def index
-  	@articles = Article.all
+    @articles = Article.all
   end
 
   def show
@@ -12,7 +12,7 @@ class ArticlesController < ApplicationController
   end
 
   def new
-  	@article = Article.new
+    @article = Article.new
   end
 
   def edit
@@ -20,13 +20,13 @@ class ArticlesController < ApplicationController
   end
 
   def create
-  	@article = Article.new(article_params)
+    @article = Article.new(article_params)
 
-  	if @article.save
-  	  redirect_to @article
-  	else
-  	  render 'new'
-  	end
+    if @article.save
+      redirect_to @article
+    else
+      render 'new'
+    end
   end
 
   def update
@@ -45,9 +45,9 @@ class ArticlesController < ApplicationController
    
     redirect_to articles_path
   end
-  
+
   private
     def article_params
-    	params.require(:article) .permit(:title, :text)
+      params.require(:article) .permit(:title, :text)
     end
 end


### PR DESCRIPTION
I think this fixes it! Looks like it was just an issue of trailing whitespace characters somehow messing up the parser. If you look at the error picture, it's looking for a method called `[SPACE]http_basic_authenticate_with`. I think it's cuz you had a mix of spaces and tab characters for your indentation. Checkout [this](http://nithinbekal.com/posts/indentation/) article. A lot of times text editors will insert tab characters when you press tab by default, but you can change it. If you're using sublime, see [here](http://www.sublimetext.com/docs/2/indentation.html)
